### PR TITLE
ElasticGit seems to lose the `es` parameter value at times.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install -e .
   - pip install coveralls
 script:
-  - py.test elasticgit -s
+  - py.test elasticgit -s --cov ./elasticgit
 after_success:
   - coveralls
 deploy:

--- a/elasticgit/tests/test_workspace.py
+++ b/elasticgit/tests/test_workspace.py
@@ -3,6 +3,7 @@ import os
 
 from elasticgit.tests.base import ModelBaseTest, TestPerson, TestPage
 from elasticgit.search import ModelMappingType
+from elasticgit.workspace import Workspace
 
 from git import Repo, GitCommandError
 
@@ -46,6 +47,12 @@ class TestWorkspace(ModelBaseTest):
         self.assertTrue(self.workspace.exists())
         self.workspace.destroy()
         self.assertFalse(self.workspace.exists())
+
+    def test_workspace_es_parameters(self):
+        temp_ws = Workspace(self.workspace.repo, es='quack quack',
+                            index_prefix=self.workspace.index_prefix)
+        qs = temp_ws.S(TestPerson)
+        self.assertEqual(qs.get_es(), 'quack quack')
 
 
 class TestEG(ModelBaseTest):

--- a/elasticgit/tests/test_workspace.py
+++ b/elasticgit/tests/test_workspace.py
@@ -49,10 +49,18 @@ class TestWorkspace(ModelBaseTest):
         self.assertFalse(self.workspace.exists())
 
     def test_workspace_es_parameters(self):
-        temp_ws = Workspace(self.workspace.repo, es='quack quack',
-                            index_prefix=self.workspace.index_prefix)
+        temp_ws = Workspace(
+            self.workspace.repo,
+            es={'urls': ['http://example.org:1234']},
+            index_prefix=self.workspace.index_prefix)
         qs = temp_ws.S(TestPerson)
-        self.assertEqual(qs.get_es(), 'quack quack')
+        transport = qs.get_es().transport
+        [host] = transport.hosts
+        self.assertEqual(host, {
+            u'host': 'example.org',
+            u'port': 1234,
+            u'scheme': 'http',
+        })
 
 
 class TestEG(ModelBaseTest):

--- a/elasticgit/workspace.py
+++ b/elasticgit/workspace.py
@@ -22,8 +22,9 @@ class Workspace(object):
 
     :param git.Repo repo:
         A :py:class:`git.Repo` instance.
-    :param elasticsearch.Elasticsearch es:
-        An Elasticsearch object.
+    :param dit es:
+        A dictionary of values one would pass to elasticutils.get_es
+        to get an Elasticsearch connection
     :param str index_prefix:
         The prefix to use when generating index names for Elasticsearch
     """
@@ -31,7 +32,9 @@ class Workspace(object):
     def __init__(self, repo, es, index_prefix):
         self.repo = repo
         self.sm = StorageManager(repo)
-        self.im = ESManager(self.sm, es, index_prefix)
+        self.es_settings = es
+        self.im = ESManager(
+            self.sm, get_es(**self.es_settings), index_prefix)
         self.working_dir = self.repo.working_dir
         self.index_prefix = index_prefix
 
@@ -313,7 +316,7 @@ class Workspace(object):
             The class to provide a search interface for.
         """
         return S(
-            self.im.get_mapping_type(model_class))
+            self.im.get_mapping_type(model_class)).es(**self.es_settings)
 
 
 class EG(object):
@@ -343,7 +346,7 @@ class EG(object):
         repo = (cls.read_repo(workdir)
                 if cls.is_repo(workdir)
                 else cls.init_repo(workdir))
-        return Workspace(repo, get_es(**es), index_prefix)
+        return Workspace(repo, es, index_prefix)
 
     @classmethod
     def dot_git_path(cls, workdir):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules --verbose --cov ./elasticgit
+addopts = --doctest-modules --verbose


### PR DESCRIPTION
There's occasions when `workspace.S()` uses the default `elasticutils` values for `es` instead of what was provided.