### PR TITLE
make originating index available on Model

### DIFF
--- a/elasticgit/models.py
+++ b/elasticgit/models.py
@@ -250,9 +250,10 @@ class Model(Config):
 
     uuid = UUIDField('Unique Identifier')
 
-    def __init__(self, config_data, static=False):
+    def __init__(self, config_data, static=False, es_meta=None):
         super(Model, self).__init__(config_data, static=static)
         self._read_only = False
+        self.es_meta = es_meta
 
     def __eq__(self, other):
         own_data = dict(self)

--- a/elasticgit/search.py
+++ b/elasticgit/search.py
@@ -115,27 +115,29 @@ class ReadWriteModelMappingType(ModelMappingTypeBase, Indexable):
             model_class, im=im, sm=sm)
 
 
-def search_results_set_objects(self, results):
-    """
-    Adds the index returned by Elasticsearch to :py:class:`Metadata` instances.
-    See also:
-    https://github.com/mozilla/elasticutils/blob/master/elasticutils/__init__.py#L1918
-    """
-    super(self.__class__, self).set_objects(results)
-    for obj, result in zip(self.objects, self.results):
+class SearchResultsMixin(object):
+
+    def set_objects(self, results):
+        """
+        Adds the index returned by Elasticsearch to :py:class:`Metadata`
+        instances. See also:
+        https://github.com/mozilla/elasticutils/blob/master/elasticutils/__init__.py#L1918
+        """
+        super(SearchResultsMixin, self).set_objects(results)
+        for obj, result in zip(self.objects, self.results):
             obj.es_meta.index = result.get('_index')
 
 
-class CustomDictSearchResults(DictSearchResults):
-    set_objects = search_results_set_objects
+class CustomDictSearchResults(SearchResultsMixin, DictSearchResults):
+    pass
 
 
-class CustomListSearchResults(ListSearchResults):
-    set_objects = search_results_set_objects
+class CustomListSearchResults(SearchResultsMixin, ListSearchResults):
+    pass
 
 
-class CustomObjectSearchResults(ObjectSearchResults):
-    set_objects = search_results_set_objects
+class CustomObjectSearchResults(SearchResultsMixin, ObjectSearchResults):
+    pass
 
 
 class S(SBase):

--- a/elasticgit/search.py
+++ b/elasticgit/search.py
@@ -3,7 +3,9 @@ from urllib import quote
 
 from git import Repo
 
-from elasticutils import MappingType, Indexable, S as SBase
+from elasticutils import (
+    MappingType, Indexable, S as SBase,
+    ObjectSearchResults, DictSearchResults, ListSearchResults)
 
 from elasticgit.utils import introspect_properties
 
@@ -113,6 +115,29 @@ class ReadWriteModelMappingType(ModelMappingTypeBase, Indexable):
             model_class, im=im, sm=sm)
 
 
+def search_results_set_objects(self, results):
+    """
+    Adds the index returned by Elasticsearch to :py:class:`Metadata` instances.
+    See also:
+    https://github.com/mozilla/elasticutils/blob/master/elasticutils/__init__.py#L1918
+    """
+    super(self.__class__, self).set_objects(results)
+    for obj, result in zip(self.objects, self.results):
+            obj.es_meta.index = result.get('_index')
+
+
+class CustomDictSearchResults(DictSearchResults):
+    set_objects = search_results_set_objects
+
+
+class CustomListSearchResults(ListSearchResults):
+    set_objects = search_results_set_objects
+
+
+class CustomObjectSearchResults(ObjectSearchResults):
+    set_objects = search_results_set_objects
+
+
 class S(SBase):
 
     def to_python(self, obj):
@@ -123,6 +148,17 @@ class S(SBase):
         timezone-aware ISO format is not recognized.
         """
         return obj
+
+    def get_results_class(self):
+        """
+        Returns the custom results class to use
+        """
+        results_class = super(S, self).get_results_class()
+        return {
+            DictSearchResults: CustomDictSearchResults,
+            ListSearchResults: CustomListSearchResults,
+            ObjectSearchResults: CustomObjectSearchResults,
+        }.get(results_class)
 
 
 class SM(S):

--- a/elasticgit/search.py
+++ b/elasticgit/search.py
@@ -43,7 +43,7 @@ class ModelMappingTypeBase(MappingType):
         raise NotImplementedError
 
     def to_object(self):
-        obj = self.model_class(self._results_dict)
+        obj = self.model_class(self._results_dict, es_meta=self.es_meta)
         obj.set_read_only()  # might not be in sync with Git
         return obj
 

--- a/elasticgit/tests/test_search.py
+++ b/elasticgit/tests/test_search.py
@@ -161,3 +161,4 @@ class TestSearch(ModelBaseTest):
         self.assertTrue(hasattr(person.es_meta, 'index'))
         self.assertEqual(person.es_meta.index,
                          '%s-master' % self.workspace1.index_prefix)
+        self.assertEqual(person.to_object().es_meta, person.es_meta)

--- a/elasticgit/tests/test_search.py
+++ b/elasticgit/tests/test_search.py
@@ -149,3 +149,15 @@ class TestSearch(ModelBaseTest):
         self.assertEqual(
             persons,
             [person1, person2])
+
+    def test_mapping_type_metadata(self):
+        person = TestPerson({
+            'age': 12,
+            'name': 'Foo'
+        })
+        self.workspace1.save(person, 'Saving person')
+        self.workspace1.refresh_index()
+        [person] = self.workspace1.S(TestPerson)
+        self.assertTrue(hasattr(person.es_meta, 'index'))
+        self.assertEqual(person.es_meta.index,
+                         '%s-master' % self.workspace1.index_prefix)


### PR DESCRIPTION
Elasticsearch returns an object's index in the `_index` field, but it gets discarded by Elasticutils [here](https://github.com/mozilla/elasticutils/blob/master/elasticutils/__init__.py#L1905).