### PR TITLE
ESManager relies on local repo

### DIFF
--- a/elasticgit/search.py
+++ b/elasticgit/search.py
@@ -89,9 +89,7 @@ class ReadWriteModelMappingType(ModelMappingTypeBase, Indexable):
 
     @classmethod
     def get_index(cls):
-        im = cls.im
-        repo = cls.sm.repo
-        return im.index_name(repo.active_branch.name)
+        return cls.im.index_name(cls.sm.active_branch())
 
     def get_object(self):
         return self.sm.get(self.model_class, self._id)


### PR DESCRIPTION
`ESManager.get_mapping_type` uses `ReadWriteModelMappingType` which is incompatible with `RemoteStorageManager`: https://github.com/universalcore/elastic-git/blob/develop/elasticgit/search.py#L277